### PR TITLE
Adding support for generating previews

### DIFF
--- a/src/Maker/PreviewMaker/MakePreviewCommand.php
+++ b/src/Maker/PreviewMaker/MakePreviewCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendsOfSulu\MakerBundle\Maker\PreviewMaker;
+
+use FriendsOfSulu\MakerBundle\Utils\NameGenerators\ResourceKeyExtractor;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Webmozart\Assert\Assert;
+
+class MakePreviewCommand extends AbstractMaker
+{
+    private const ARG_RESOURCE_CLASS = 'resource-class';
+
+    public function __construct(
+        private ResourceKeyExtractor $resourceKeyExtractor,
+    ) {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:sulu:preview';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command->addArgument(self::ARG_RESOURCE_CLASS, InputOption::VALUE_REQUIRED, 'The resource class to be previewed');
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        /** @var string $resourceClass */
+        $resourceClass = $input->getArgument(self::ARG_RESOURCE_CLASS);
+        Assert::classExists($resourceClass);
+        $resourceClassName = Str::getShortClassName($resourceClass);
+
+        $classNameDetails = $generator->createClassNameDetails(
+            name: $resourceClassName,
+            namespacePrefix: 'PreviewProvider\\',
+            suffix: 'PreviewProvider'
+        );
+        $resourceKey = $this->resourceKeyExtractor->getUniqueName($resourceClass);
+
+        if (\is_a($resourceClass, '\Sulu\Bundle\ContentBundle\Content\Domain\Model\ContentRichEntityInterface', true)) {
+            $io->info([<<<EOT
+                There is already a class for that. You just need to register a service like this:
+
+                app.{$resourceKey}_object_provider:
+                    class: 'Sulu\Bundle\ContentBundle\Content\Infrastructure\Sulu\Preview\ContentObjectProvider'
+                    arguments:
+                        \$contentRichEntityClass: '$resourceClass'
+                    tags:
+                        - {name: 'sulu_preview.object_provider', 'provider-key': '$resourceKey'}
+                EOT,
+            ]);
+
+            return;
+        }
+
+        $useStatements = new UseStatementGenerator([
+            'Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderInterface',
+            $resourceClass,
+        ]);
+
+        $generator->generateClass(
+            $classNameDetails->getFullName(),
+            __DIR__ . '/preview_provider_template.tpl.php',
+            [
+                'use_statements' => $useStatements,
+                'resource_class' => $resourceClassName,
+            ]
+        );
+
+        $templateName = 'admin_preview/' . Str::asTwigVariable($resourceClassName);
+        $generator->generateTemplate(
+            $templateName . '.html.twig',
+            __DIR__ . '/preview_template.tpl.php',
+            [
+                'resource_key' => $resourceKey,
+            ]
+        );
+        $generator->writeChanges();
+
+        $io->info(<<<TEXT
+            Next steps:
+            * Add the generated view to your XML template configuration under: config/template/$resourceKey
+            Like this:
+            <template>
+                ...
+                <view>$templateName</view>
+                ...
+            </template>
+
+            * Fill the template with your preview content
+            * In the {$resourceKey}Admin class use the `createPreviewFormBuilder` method instead of `createFormViewBuilder`
+            TEXT);
+    }
+}

--- a/src/Maker/PreviewMaker/preview_provider_template.tpl.php
+++ b/src/Maker/PreviewMaker/preview_provider_template.tpl.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @var string $namespace
+ * @var string $class_name
+ * @var string $resource_class
+ * @var \Symfony\Bundle\MakerBundle\Util\UseStatementGenerator $use_statements
+ */
+echo '<?php'; ?>
+
+declare(strict_types=1);
+
+namespace <?= $namespace; ?>;
+
+<?= $use_statements; ?>
+
+class <?= $class_name; ?> implements PreviewObjectProviderInterface
+{
+    public function getObject($id, $locale): <?= $resource_class; ?>
+    {
+    }
+
+    public function getId($object): string
+    {
+    }
+
+    public function setValues($object, $locale, array $data): void
+    {
+    }
+
+    public function setContext($object, $locale, array $context)
+    {
+    }
+
+    public function serialize($object): string
+    {
+    }
+
+    public function deserialize($serializedObject, $objectClass): <?= $resource_class; ?>
+    {
+    }
+
+    public function getSecurityContext($id, $locale): ?string
+    {
+    }
+}
+

--- a/src/Maker/PreviewMaker/preview_template.tpl.php
+++ b/src/Maker/PreviewMaker/preview_template.tpl.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @var string $resource_key
+ */
+?>
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Preview of <?= $resource_key; ?></title>
+    </head>
+    <body>
+        {% block content %}
+            <!-- Put your rendering code here -->
+            {{ dump() }}
+        {% endblock %}
+    </body>
+</html>

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -4,6 +4,7 @@ use FriendsOfSulu\MakerBundle\Maker\AdminConfigurationMaker\MakeAdminConfigurati
 use FriendsOfSulu\MakerBundle\Maker\ControllerMaker\MakeControllerCommand;
 use FriendsOfSulu\MakerBundle\Maker\ListConfigurationMaker\ListPropertyInfoProvider;
 use FriendsOfSulu\MakerBundle\Maker\ListConfigurationMaker\MakeListConfigurationCommand;
+use FriendsOfSulu\MakerBundle\Maker\PreviewMaker\MakePreviewCommand;
 use FriendsOfSulu\MakerBundle\Maker\SuluPageMaker\MakePageTypeCommand;
 use FriendsOfSulu\MakerBundle\Maker\TashHandlerMaker\MakeTrashHandlerCommand;
 use FriendsOfSulu\MakerBundle\Property\PropertyToSuluTypeGuesser;
@@ -16,6 +17,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 return function(ContainerConfigurator $configurator) {
     $services = $configurator->services();
 
+    // Maker commands
     $services
         ->set(MakeListConfigurationCommand::class)
         ->args([
@@ -47,14 +49,20 @@ return function(ContainerConfigurator $configurator) {
         ->tag('maker.command')
     ;
 
+    $services->set(MakeTrashHandlerCommand::class)
+        ->tag('maker.command')
+    ;
+
+    $services->set(MakePreviewCommand::class)
+        ->args([service(ResourceKeyExtractor::class)])
+        ->tag('maker.command')
+    ;
+
+    // Other services
     $services->set(ListPropertyInfoProvider::class)
         ->args([
             service(PropertyToSuluTypeGuesser::class),
         ]);
-
-    $services->set(MakeTrashHandlerCommand::class)
-        ->tag('maker.command')
-    ;
 
     $services->set(PropertyToSuluTypeGuesser::class);
     $services->set(ResourceKeyExtractor::class);


### PR DESCRIPTION
Closes #4 

## Things I found out while working this
- The maker bundle has a class name generator (`createClassNameDetails`)
- We don't really have a best practice in Sulu where classes are put so they're now where they would be in Symonfy (directly under `src/PreviewProvider/EventPreviewProvider.php` and that's not configurable)
- Modifying the config xml would be easy but finding the right file to modify is hard (that's why it's still a manual step).