### PR TITLE
Using attribute routing when generating AdminControllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ namespace App\Entity;
 
 class Changelog
 {
-    public static $RESOURCE_KEY = 'changelog';
-    // or...
     public const RESOURCE_KEY = 'changelog';
 
     public ?int $id = null;

--- a/src/Maker/ControllerMaker/controllerTemplate.tpl.php
+++ b/src/Maker/ControllerMaker/controllerTemplate.tpl.php
@@ -17,10 +17,7 @@ namespace <?= $namespace; ?>;
 use <?= $resourceClass; ?>;
 <?= $use_statements; ?>
 
-/**
- * @RouteResource("<?= $resourceKey; ?>")
- */
-class <?= $class_name; ?> implements ClassResourceInterface
+class <?= $class_name; ?>
 {
 
     public function __construct(
@@ -40,6 +37,11 @@ class <?= $class_name; ?> implements ClassResourceInterface
     }
 <?php if ($settings->shouldHaveGetListAction) { ?>
 
+    #[Route(
+        '/<?= $resourceKey; ?>',
+        name: 'app_admin.<?= $resourceKey; ?>.list',
+        methods: ['GET'],
+    )]
     public function cgetAction(): Response
     {
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors(<?= $resourceClassName; ?>::RESOURCE_KEY);
@@ -59,6 +61,11 @@ class <?= $class_name; ?> implements ClassResourceInterface
 <?php } ?>
 <?php if ($settings->shouldHaveGetAction) { ?>
 
+    #[Route(
+        '/<?= $resourceKey; ?>/{id}',
+        name: 'app_admin.<?= $resourceKey; ?>.get',
+        methods: ['GET'],
+    )]
     public function getAction(string $id): Response
     {
         $entity = $this->entityManager->find(<?= $resourceClassName; ?>::class, $id);
@@ -71,37 +78,59 @@ class <?= $class_name; ?> implements ClassResourceInterface
 <?php } ?>
 <?php if ($settings->shouldHavePostAction) { ?>
 
+    #[Route(
+        '/<?= $resourceKey; ?>',
+        name: 'app_admin.<?= $resourceKey; ?>.post',
+        methods: ['POST'],
+    )]
     public function postAction(Request $request): Response
     {
-        $productFilterConfiguration = new <?= $resourceClassName; ?>();
-        $this->mapDataFromRequest($request, $productFilterConfiguration);
+        $entity = new <?= $resourceClassName; ?>();
+        $this->mapDataFromRequest($request, $entity);
 
-        $this->entityManager->persist($productFilterConfiguration);
+        $this->entityManager->persist($entity);
         $this->entityManager->flush();
 
-        return $this->viewHandler->handle(View::create($productFilterConfiguration));
+        return $this->viewHandler->handle(View::create($entity));
     }
 <?php } ?>
 <?php if ($settings->shouldHavePutAction) { ?>
 
+    #[Route(
+        '/<?= $resourceKey; ?>/{id}',
+        name: 'app_admin.<?= $resourceKey; ?>.put',
+        methods: ['PUT'],
+    )]
     public function putAction(string $id, Request $request): Response
     {
-        $productConfiguration = $this->entityManager->find(<?= $resourceClassName; ?>::class, $id);
-        $this->mapDataFromRequest($request, $productConfiguration);
+        $entity = $this->entityManager->find(<?= $resourceClassName; ?>::class, $id);
+        if ($entity === null) {
+            return new Response('', Response::HTTP_NOT_FOUND);
+        }
+
+        $this->mapDataFromRequest($request, $entity);
 
         $this->entityManager->flush();
 
-        return $this->viewHandler->handle(View::create($productConfiguration));
+        return $this->viewHandler->handle(View::create($entity));
     }
 <?php } ?>
 <?php if ($settings->shouldHaveDeleteAction) { ?>
 
+    #[Route(
+        '/<?= $resourceKey; ?>/{id}',
+        name: 'app_admin.<?= $resourceKey; ?>.delete',
+        methods: ['DELETE'],
+    )]
     public function deleteAction(string $id): Response
     {
         $entity = $this->entityManager->find(<?= $resourceClassName; ?>::class, $id);
+        if ($entity === null) {
+            return new Response('', Response::HTTP_NOT_FOUND);
+        }
 
 <?php if ($settings->shouldHaveTrashing) { ?>
-        $this->trashManager->store('<?= $resourceKey; ?>', $listingTile);
+        $this->trashManager->store('<?= $resourceKey; ?>', $entity);
 <?php } ?>
 
         $this->entityManager->remove($entity);

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -50,6 +50,7 @@ return function(ContainerConfigurator $configurator) {
     $services
         ->set(MakeControllerCommand::class)
         ->args([
+            '%kernel.project_dir%',
             service(ResourceKeyExtractor::class),
             service('maker.doctrine_helper'),
         ])


### PR DESCRIPTION
# What's inside
* Fixing generated code 
    * it was using variables that were never set
    * Not properly return a 404 when no entity was found
    * Fixing errors phpstan found when running over the generated code
* Removing documentation about "public static" properties being supported. This would make the code more complicated. Sulu only uses constants so we should be fine to enforce this here.
* Only show the "add yaml to your application" for the first time and then autoconfiguring works for the rest of the time.